### PR TITLE
Fixed redirect URL issue

### DIFF
--- a/src/upstream/upstream.ts
+++ b/src/upstream/upstream.ts
@@ -9,8 +9,5 @@ const GATEWAY_URL = `https://perma.online`;
  */
 export async function getRedirectedUrl(tx: string) {
   const resp = await ax.get(`${GATEWAY_URL}/${tx}`, { maxRedirects: 0, validateStatus: () => true })
-  if (resp.status !== 301) {
-    return resp.status;
-  }
   return resp.headers.location as string;
 }


### PR DESCRIPTION
Due to the return URL it was causing an issue to deliver the page. Removing the extra check for 301 which is not required anymore.